### PR TITLE
fix(parsers/fstChars): include whitespace characters

### DIFF
--- a/src/parsers/index.ts
+++ b/src/parsers/index.ts
@@ -59,7 +59,7 @@ const lstWord = compose(lstToken, words);
 
 // extract first WINDOW_WIDTH characters
 const fstChars = (width = WINDOW_WIDTH) => {
-    const fstCharsPattern = `^.{0,${width}}`;
+    const fstCharsPattern = `^[\\s\\S]{0,${width}}`;
     const fstCharsFlags = 'gmu';
     const fstCharsRegExp = new RegExp(fstCharsPattern, fstCharsFlags);
 


### PR DESCRIPTION
consume whitespace characters as well as other characters when parsing next WINDOW_WIDTH characters.

allows for newlines as well as tabs to be legal separator between sentences.