### PR TITLE
fix: add block rule rightStartsWithUppercase

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import {
     rightStartsNewlineUppercased,
     rightStartsWithHardbreak,
     rightStartsWithLowercase,
+    rightStartsWithUppercase,
     spaceBothSides,
 } from './rules';
 
@@ -44,6 +45,7 @@ const breakCondition = anyPass([
     leftEndsWithHardbreak,
     rightStartsWithHardbreak,
     rightStartsNewlineUppercased,
+    rightStartsWithUppercase,
 ]);
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/rules/base.ts
+++ b/src/rules/base.ts
@@ -87,6 +87,11 @@ export const rightStartsWithLowercase = rule('rightStartsWithLowercase', [
     compose(startsWithLower, fstToken),
 ]);
 
+export const rightStartsWithUppercase = rule('rightStartsWithUppercase', [
+    _,
+    compose(startsWithUpper, fstToken),
+]);
+
 // todo: determine if right is a delimiter
 export const rightDelimiterPrefix = rule('rightDelimiterPrefix', [
     _,


### PR DESCRIPTION
correcting the abbreviation at the end of the sentence